### PR TITLE
Moved init and deletion code from run to constructor and destructor

### DIFF
--- a/Lua_Irrlicht_BTH_template/Game.h
+++ b/Lua_Irrlicht_BTH_template/Game.h
@@ -165,7 +165,7 @@ private:
 
 	static gui::IGUIFont* font;
 	void render();//C++
-	void initialize();
+	void initIrrlicht();
 	void update() const;//LUA
 	void initLua();
 


### PR DESCRIPTION
This change makes the Game class use more RAII. Now the destructor drops and closes lua and the constructor handles the initialization of Irrlicht and lua.

-Changed the name of initialize to initIrrlicht and moved the calling code from run to the constructor of Game. 
-Moved initLua call and setting the cursor visible to constructor of Game. 
-Moved the code after the running while loop in Run() to destructor of Game. Dropping the device and closing lua. 
-Moved initLua and initIrrlicht definitions higher in the file below destructor. This makes more senses since they are both initializers.