### PR TITLE
Added constants for settings.

### DIFF
--- a/Lua_Irrlicht_BTH_template/Game.cpp
+++ b/Lua_Irrlicht_BTH_template/Game.cpp
@@ -30,9 +30,9 @@ Game::~Game()
 void Game::initIrrlicht()
 {
 	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
-	params.AntiAlias = 4;
-	params.DriverType = video::EDT_OPENGL;
-	params.WindowSize = core::dimension2d<u32>(1280, 720);
+	params.AntiAlias = ANTIALIAS;
+	params.DriverType = DRIVERTYPE;
+	params.WindowSize = WINDOWSIZE;
 	params.EventReceiver = &eventRec;
 
 	this->device = irr::createDeviceEx(params);
@@ -44,11 +44,11 @@ void Game::initIrrlicht()
 
 
 	//Set default settings and a camera for irrlicht
-	device->getFileSystem()->changeWorkingDirectoryTo("Lua_Irrlicht_BTH_template");
+	device->getFileSystem()->changeWorkingDirectoryTo(CWD);
 	
-	font = device->getGUIEnvironment()->getFont("myfont.xml");
+	font = device->getGUIEnvironment()->getFont(DEFAULTFONT);
 
-	this->camera = smgr->addCameraSceneNode((irr::scene::ISceneNode*)0, core::vector3df(0, 50, -1), core::vector3df(0, 0, 0));
+	this->camera = smgr->addCameraSceneNode((irr::scene::ISceneNode*)0, DEFAULTCAMERAPOSITION, DEFAULTCAMERALOOKAT);
 
 	guienv->addImage(driver->getTexture("3DObjects/cube2.tga"),
 		core::position2d<int>(10, 10));
@@ -489,7 +489,7 @@ void Game::render()
 {
 	if (device->isWindowActive())
 	{
-		driver->beginScene(true, true, irr::video::SColor(255, 0, 0, 200));
+		driver->beginScene(true, true, CLEARCOLOR);
 		smgr->drawAll();
 		guienv->drawAll();
 		driver->endScene();

--- a/Lua_Irrlicht_BTH_template/Game.h
+++ b/Lua_Irrlicht_BTH_template/Game.h
@@ -162,8 +162,17 @@ private:
 	static irr::scene::ICameraSceneNode* camera;
 	const static irr::scene::IGeometryCreator* geomentryCreator;
 	static float deltaTime;
-
 	static gui::IGUIFont* font;
+
+	const irr::video::SColor CLEARCOLOR = irr::video::SColor(255, 0, 0, 200);
+	const irr::u8 ANTIALIAS = 4;
+	const irr::video::E_DRIVER_TYPE DRIVERTYPE = irr::video::EDT_OPENGL;
+	const core::dimension2d<u32> WINDOWSIZE = core::dimension2d<u32>(1280, 720);
+	const irr::io::path CWD = irr::io::path("Lua_Irrlicht_BTH_template");
+	const irr::io::path DEFAULTFONT = irr::io::path("myfont.xml");
+	const core::vector3df DEFAULTCAMERALOOKAT = core::vector3df(0, 0, 0);
+	const core::vector3df DEFAULTCAMERAPOSITION = core::vector3df(0, 50, -1);
+
 	void render();//C++
 	void initIrrlicht();
 	void update() const;//LUA


### PR DESCRIPTION
With these constants it is easier to change these settings by only going to the Game.h file and changing the variable. They use the same value as the value passed to each function.

These constants are used in initIrrlicht and are used as default settings 

- Added antialias constant ANTIALIAS to be used when creating the device. 
- Added driver type constant DRIVERTYPE for creating the device. -Window size constant WINDOWSIZE
- Current working directory constant CWD for irrlicht device. -default font constant DEFAULTFONT.
- DEFAULTCAMERALOOKAT and DEFAULTCAMERAPOSITION constant
 
These constants are used in run()

- CLEARCOLOR which is used in run() for the driver function beginScene() and is used as the back buffer clear color.