### PR TITLE
Moved widetext and myeventreciever to their own files

### DIFF
--- a/Lua_Irrlicht_BTH_template/Game.cpp
+++ b/Lua_Irrlicht_BTH_template/Game.cpp
@@ -94,9 +94,9 @@ void Game::initLua()
 	lua_setglobal(L, "C_getText");
 
 	luaL_dofile(L, "LuaScripts/Init.lua");
+	//Load and call update.lua script to push the global Update function in the lua script.
+	//This Lua global Update function is then called in Game::update()
 	luaL_dofile(L, "LuaScripts/update.lua");
-
-
 }
 
 void Game::run()
@@ -517,3 +517,5 @@ void Game::update() const
 		luaL_error(L, "unknown script function %s", "Update");
 	}
 }
+
+

--- a/Lua_Irrlicht_BTH_template/Game.h
+++ b/Lua_Irrlicht_BTH_template/Game.h
@@ -14,121 +14,27 @@
 #include <vector>
 #include <string>
 #include <irrlicht.h>
-#include <comdef.h>  
+#include <comdef.h>
+#include"MyEventReceiver.h"
+#include"WideText.h"
 using namespace irr;
-class MyEventReceiver : public irr::IEventReceiver
-{
-public:
-	struct SMouseState
-	{
-		core::position2di position;
-		bool leftButtonDown;
-		bool rightButtonDown;
-		SMouseState() : leftButtonDown(false), rightButtonDown(false)
-		{
-
-		}
-	} MouseState;
-
-	// This is the one method that we have to implement
-	virtual bool OnEvent(const irr::SEvent& event)
-	{
-		if (event.EventType == EET_MOUSE_INPUT_EVENT)
-		{
-			switch (event.MouseInput.Event)
-			{
-			case EMIE_LMOUSE_PRESSED_DOWN:
-				MouseState.leftButtonDown = true;
-				break;
-
-			case EMIE_LMOUSE_LEFT_UP:
-				MouseState.leftButtonDown = false;
-				break;
-
-			case EMIE_RMOUSE_PRESSED_DOWN:
-				MouseState.rightButtonDown = true;
-				break;
-
-			case EMIE_RMOUSE_LEFT_UP:
-				MouseState.rightButtonDown = false;
-				break;
-
-			case EMIE_MOUSE_MOVED:
-				MouseState.position.X = event.MouseInput.X;
-				MouseState.position.Y = event.MouseInput.Y;
-				break;
-
-			default:
-				break;
-			}
-		}
-		// Remember whether each key is down or up
-		if (event.EventType == irr::EET_KEY_INPUT_EVENT)
-			KeyIsDown[event.KeyInput.Key] = event.KeyInput.PressedDown;
-
-		return false;
-	}
-
-	const SMouseState& getMouseState() const
-	{
-		return MouseState;
-	}
-
-	// This is used to check whether a key is being held down
-	virtual bool IsKeyDown(irr::EKEY_CODE keyCode) const
-	{
-		return KeyIsDown[keyCode];
-	}
-
-	MyEventReceiver()
-	{
-		for (irr::u32 i = 0; i < irr::KEY_KEY_CODES_COUNT; ++i)
-			KeyIsDown[i] = false;
-	}
-
-private:
-	// We use this array to store the current state of each key
-	bool KeyIsDown[irr::KEY_KEY_CODES_COUNT];
-
-};
-class WideText
-{
-public:
-	WideText(const char* text)
-	{
-		const size_t cSize = strlen(text) + 1;
-		wchar = new wchar_t[cSize];
-		size_t outSize;
-		mbstowcs_s(&outSize, wchar, cSize, text, cSize - 1);
-	}
-	~WideText()
-	{
-		delete[] wchar;
-	}
-	wchar_t* getWideChar()
-	{
-		return wchar;
-	}
-private:
-	wchar_t* wchar;
-};
-struct Stage
-{
-	uint32_t height;
-	uint32_t width;
-	int grid[1024]; // 32 x 32
-};
-enum DrawType
-{
-	MESH,
-	BUTTON,
-	TEXT,
-	EDITBOX,
-	IMAGE
-};
 class Game
 {
 public:
+	struct Stage
+	{
+		uint32_t height;
+		uint32_t width;
+		int grid[1024]; // 32 x 32
+	};
+	enum DrawType
+	{
+		MESH,
+		BUTTON,
+		TEXT,
+		EDITBOX,
+		IMAGE
+	};
 	Game();
 	~Game();
 	void run();

--- a/Lua_Irrlicht_BTH_template/Lua_Irrlicht_BTH_template.vcxproj
+++ b/Lua_Irrlicht_BTH_template/Lua_Irrlicht_BTH_template.vcxproj
@@ -148,6 +148,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="MyEventReceiver.cpp" />
     <ClCompile Include="testLoad.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
@@ -160,6 +161,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="WideText.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Game.h" />
@@ -169,6 +171,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="MyEventReceiver.h" />
+    <ClInclude Include="WideText.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Lua_Irrlicht_BTH_template/Lua_Irrlicht_BTH_template.vcxproj.filters
+++ b/Lua_Irrlicht_BTH_template/Lua_Irrlicht_BTH_template.vcxproj.filters
@@ -30,12 +30,24 @@
     <ClCompile Include="testLoad.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MyEventReceiver.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WideText.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Gameobject.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Game.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MyEventReceiver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WideText.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Lua_Irrlicht_BTH_template/MyEventReceiver.cpp
+++ b/Lua_Irrlicht_BTH_template/MyEventReceiver.cpp
@@ -1,0 +1,60 @@
+#include"MyEventReceiver.h"
+
+// This is the one method that we have to implement
+bool MyEventReceiver::OnEvent(const irr::SEvent& event)
+{
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT)
+	{
+		switch (event.MouseInput.Event)
+		{
+		case irr::EMIE_LMOUSE_PRESSED_DOWN:
+			mouseState.leftButtonDown = true;
+			break;
+
+		case irr::EMIE_LMOUSE_LEFT_UP:
+			mouseState.leftButtonDown = false;
+			break;
+
+		case irr::EMIE_RMOUSE_PRESSED_DOWN:
+			mouseState.rightButtonDown = true;
+			break;
+
+		case irr::EMIE_RMOUSE_LEFT_UP:
+			mouseState.rightButtonDown = false;
+			break;
+
+		case irr::EMIE_MOUSE_MOVED:
+			mouseState.position.X = event.MouseInput.X;
+			mouseState.position.Y = event.MouseInput.Y;
+			break;
+
+		default:
+			break;
+		}
+	}
+	// Remember whether each key is down or up
+	if (event.EventType == irr::EET_KEY_INPUT_EVENT)
+		KeyIsDown[event.KeyInput.Key] = event.KeyInput.PressedDown;
+
+	return false;
+}
+
+const SMouseState& MyEventReceiver::getMouseState() const
+{
+	return mouseState;
+}
+
+// This is used to check whether a key is being held down
+
+bool MyEventReceiver::IsKeyDown(irr::EKEY_CODE keyCode) const
+{
+	return KeyIsDown[keyCode];
+}
+
+MyEventReceiver::MyEventReceiver()
+{
+	for (irr::u32 i = 0; i < irr::KEY_KEY_CODES_COUNT; ++i)
+		KeyIsDown[i] = false;
+	
+	memset(&mouseState, 0, sizeof(SMouseState));
+}

--- a/Lua_Irrlicht_BTH_template/MyEventReceiver.h
+++ b/Lua_Irrlicht_BTH_template/MyEventReceiver.h
@@ -1,0 +1,32 @@
+#pragma once
+#include<irrlicht.h>
+struct SMouseState
+{
+	irr::core::position2di position;
+	bool leftButtonDown;
+	bool rightButtonDown;
+	SMouseState()
+	{
+		leftButtonDown = false;
+		rightButtonDown = false;
+	};
+};
+class MyEventReceiver : public irr::IEventReceiver
+{
+public:
+	// This is the one method that we have to implement
+	virtual bool OnEvent(const irr::SEvent& event);
+
+	const SMouseState& getMouseState() const;
+
+	// This is used to check whether a key is being held down
+	virtual bool IsKeyDown(irr::EKEY_CODE keyCode) const;
+
+	MyEventReceiver();
+
+private:
+	// We use this array to store the current state of each key
+	bool KeyIsDown[irr::KEY_KEY_CODES_COUNT];
+
+	SMouseState mouseState;
+};

--- a/Lua_Irrlicht_BTH_template/WideText.cpp
+++ b/Lua_Irrlicht_BTH_template/WideText.cpp
@@ -1,0 +1,20 @@
+#include "WideText.h"
+#include <stdlib.h>
+#include <string.h>
+WideText::WideText(const char* text)
+{
+	const size_t cSize = strlen(text) + 1;
+	wchar = new wchar_t[cSize];
+	size_t outSize;
+	mbstowcs_s(&outSize, wchar, cSize, text, cSize - 1);
+}
+
+WideText::~WideText()
+{
+	delete[] wchar;
+}
+
+wchar_t* WideText::getWideChar()
+{
+	return wchar;
+}

--- a/Lua_Irrlicht_BTH_template/WideText.h
+++ b/Lua_Irrlicht_BTH_template/WideText.h
@@ -1,0 +1,11 @@
+#pragma once
+class WideText
+{
+public:
+	WideText(const char* text);
+	~WideText();
+	wchar_t* getWideChar();
+private:
+	wchar_t* wchar;
+};
+


### PR DESCRIPTION
Moved these classes from Game into their own .h and .cpp file and included them in Game.h:
- WideText
- MyEventReceiver

Moved declaration of enum DrawType and struct Stage into the Game class public member variables.
Added a comment describing why we call luaL_dofile with update.lua in initLua
