### PR TITLE
Split game and engine

### DIFF
--- a/Lua_Irrlicht_BTH_template/Game.cpp
+++ b/Lua_Irrlicht_BTH_template/Game.cpp
@@ -89,6 +89,8 @@ void Game::initLua()
 	lua_setglobal(L, "C_setTexture");
 	lua_pushcfunction(L, this->C_getText);
 	lua_setglobal(L, "C_getText");
+	lua_pushcfunction(L, this->C_setFont);
+	lua_setglobal(L, "C_setFont");
 
 	luaL_dofile(L, "LuaScripts/Init.lua");
 	//Load and call update.lua script to push the global Update function in the lua script.
@@ -117,7 +119,11 @@ int Game::C_addToDraw(lua_State* L)
 	if (type == DrawType::MESH)
 	{
 		//mesh
-
+		int top = lua_gettop(L);
+		if (top != 1)
+		{
+			std::cerr << "Error, not enought parameters were passed\n";
+		}
 		const char* model = lua_tostring(L, -1);
 		lua_pop(L, 1);
 		irr::scene::IMesh* mesh = smgr->getMesh(model);//change to model
@@ -131,6 +137,11 @@ int Game::C_addToDraw(lua_State* L)
 	else if (type == DrawType::BUTTON)
 	{
 		//button
+		int top = lua_gettop(L);
+		if (top != 1)
+		{
+			std::cerr << "Error, not enought parameters were passed\n";
+		}
 
 		const char* texture = lua_tostring(L, -1);
 
@@ -146,6 +157,12 @@ int Game::C_addToDraw(lua_State* L)
 	else if (type == DrawType::TEXT)
 	{
 		//text
+
+		int top = lua_gettop(L);
+		if (top != 5)
+		{
+			std::cerr << "Error, not enought parameters were passed\n";
+		}
 
 		int x = (int)lua_tonumber(L, -5);
 		int y = (int)lua_tonumber(L, -4);
@@ -166,6 +183,11 @@ int Game::C_addToDraw(lua_State* L)
 	}
 	else if (type == DrawType::EDITBOX)
 	{
+		int top = lua_gettop(L);
+		if (top != 5)
+		{
+			std::cerr << "Error, not enought parameters were passed\n";
+		}
 		int x = (int)lua_tonumber(L, -5);
 		int y = (int)lua_tonumber(L, -4);
 		int x1 = (int)lua_tonumber(L, -3);
@@ -182,6 +204,12 @@ int Game::C_addToDraw(lua_State* L)
 	}
 	else if (type == DrawType::IMAGE)
 	{
+		int top = lua_gettop(L);
+		if (top != 3)
+		{
+			std::cerr << "Error, not enought parameters were passed\n";
+		}
+
 		int x = (int)lua_tonumber(L, -3);
 		int y = (int)lua_tonumber(L, -2);
 
@@ -492,6 +520,50 @@ int Game::C_getText(lua_State* L)
 		lua_pushstring(L, text);
 	}
 	return 1;
+}
+int Game::C_setFont(lua_State* L)
+{
+	if (lua_gettop(L) != 3)
+	{
+		std::cerr << "Not enought parameters for C_setFont\n" << lua_gettop(L) << " passed\n";
+		return -1;
+	}
+	int type = (int)lua_tonumber(L, -2);
+	lua_remove(L, -2);
+	if (type == DrawType::BUTTON)
+	{
+		gui::IGUIButton* button = (gui::IGUIButton*)lua_touserdata(L, -2);
+		const char* fontPath = lua_tostring(L, -1);
+		if (button != nullptr)
+		{
+			const irr::io::path irrPath(fontPath);
+			irr::gui::IGUIFont* irrFont = guienv->getFont(irrPath);
+			if (irrFont == nullptr)
+			{
+				std::cerr << "Couldn't load the font: " << irrPath.c_str() << "\n";
+			}
+			button->setOverrideFont(irrFont);
+		}
+		lua_pop(L, 2);
+	}
+	else if (type == DrawType::TEXT)
+	{
+		gui::IGUIStaticText* text = (gui::IGUIStaticText*)lua_touserdata(L, -2);
+		const char* fontPath = lua_tostring(L, -1);
+		if (text != nullptr)
+		{
+			const irr::io::path irrPath(fontPath);
+			irr::gui::IGUIFont* irrFont = guienv->getFont(irrPath);
+			if (irrFont == nullptr)
+			{
+				std::cerr << "Couldn't load the font: " << irrPath.c_str() << "\n";
+			}
+			text->setOverrideFont(irrFont);
+		}
+		lua_pop(L, 2);
+	}
+
+	return 0;
 }
 void Game::render()
 {

--- a/Lua_Irrlicht_BTH_template/Game.cpp
+++ b/Lua_Irrlicht_BTH_template/Game.cpp
@@ -49,9 +49,6 @@ void Game::initIrrlicht()
 	font = device->getGUIEnvironment()->getFont(DEFAULTFONT);
 
 	this->camera = smgr->addCameraSceneNode((irr::scene::ISceneNode*)0, DEFAULTCAMERAPOSITION, DEFAULTCAMERALOOKAT);
-
-	guienv->addImage(driver->getTexture("3DObjects/cube2.tga"),
-		core::position2d<int>(10, 10));
 }
 
 void Game::initLua()
@@ -192,7 +189,18 @@ int Game::C_addToDraw(lua_State* L)
 
 		core::vector2di position(x, y);
 
-		gui::IGUIImage* image = guienv->addImage(driver->getTexture(texture), position);
+		gui::IGUIImage* image = nullptr;
+		irr::video::ITexture* irrTexture = nullptr;
+		irrTexture = driver->getTexture(texture);
+		if (irrTexture == nullptr)
+		{
+			std::cerr << " Error loading texture \n";
+		}
+		image = guienv->addImage(irrTexture, position);
+		if (image == nullptr)
+		{
+			std::cerr << " Error adding image \n";
+		}
 		lua_pop(L, 3);
 		lua_pushlightuserdata(L, image);
 	}

--- a/Lua_Irrlicht_BTH_template/Game.h
+++ b/Lua_Irrlicht_BTH_template/Game.h
@@ -58,6 +58,7 @@ public:
 	static int C_getDeltaTime(lua_State* L);
 	static int C_setText(lua_State* L);
 	static int C_getText(lua_State* L);
+	static int C_setFont(lua_State* L);
 	lua_State* L;
 private:
 	static MyEventReceiver eventRec;

--- a/Lua_Irrlicht_BTH_template/LuaScripts/Init.lua
+++ b/Lua_Irrlicht_BTH_template/LuaScripts/Init.lua
@@ -117,18 +117,22 @@ C_setCamTarget(6*13,0,6*13)
 C_setCamPos(150, 80, 6*13)
 --UI
 
+panelPtr = nil
+panelPtr = C_addToDraw(10, 10 ,DrawType.IMAGE, "3DObjects/cube2.tga")
+--C_setUIPos(panel, 10, 10)
+
+
 changeEM = Button:new()
 changeEM:addToDraw("3DObjects/buttonWaypoint.tga")
 changeEM:setPosition(0,400)
 changeEM:setFunction(function ()
-if MODE_WP then
-    MODE_WP = false
-    MODE_C = true
-elseif MODE_C then
-    MODE_C = false
-    MODE_WP = true
-end
-
+    if MODE_WP then
+        MODE_WP = false
+        MODE_C = true
+    elseif MODE_C then
+        MODE_C = false
+        MODE_WP = true
+    end
 end)
 
 

--- a/Lua_Irrlicht_BTH_template/LuaScripts/Init.lua
+++ b/Lua_Irrlicht_BTH_template/LuaScripts/Init.lua
@@ -23,6 +23,7 @@ UI = {buttons = {}, text = {}}
 GAME_UI = {buttons = {}, text = {}}
 EDIT_UI = {buttons = {}, text = {}}
 MODETEXT = C_addToDraw(1200, 600, 1300, 700, DrawType.TEXT, "")
+C_setFont(MODETEXT, DrawType.TEXT, "myfont.xml")
 textBox = C_addToDraw(1000, 600, 1300, 700, DrawType.EDITBOX, "")
 PLAYER_HP = 100
 function loadGrid(fileName)
@@ -217,7 +218,7 @@ C_setText(coinsText,"$"..tostring(COINS))
 isPressed = false
 isPressed2 = false
 
-hpText = C_addToDraw(120,160,160,200,2,"HP:")
+hpText = C_addToDraw(120,160,160,200,DrawType.TEXT,"HP:")
 C_setText(hpText,"HP:" .. tostring(PLAYER_HP))
 
 --Game


### PR DESCRIPTION
Panel image on game side and font can now be changed per text and button.
- The panel image for hp and money text backround is now added on the Game side(lua).
- Font can now be changed on Game side(lua) by calling C_setFont with button or text pointer, Draw type, and font path.
Currently it only supports xml file fonts. C_setFont(ptr, drawType, fontPath)